### PR TITLE
interface as variable

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -77,7 +77,10 @@ sudo apt-mark hold kubelet kubeadm kubectl
 
 sudo apt-get install -y jq
 
-local_ip="$(ip --json addr show eth0 | jq -r '.[0].addr_info[] | select(.family == "inet") | .local')"
+# detects the network interface
+interface=$(ip route | grep default | awk '{print $5}')
+
+local_ip="$(ip --json addr show $interface | jq -r '.[0].addr_info[] | select(.family == "inet") | .local')"
 cat > /etc/default/kubelet << EOF
 KUBELET_EXTRA_ARGS=--node-ip=$local_ip
 EOF

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -14,11 +14,14 @@ POD_CIDR="192.168.0.0/16"
 
 sudo kubeadm config images pull
 
+# detects the network interface
+interface=$(ip route | grep default | awk '{print $5}')
+
 # Initialize kubeadm based on PUBLIC_IP_ACCESS
 
 if [[ "$PUBLIC_IP_ACCESS" == "false" ]]; then
     
-    MASTER_PRIVATE_IP=$(ip addr show eth0 | awk '/inet / {print $2}' | cut -d/ -f1)
+    MASTER_PRIVATE_IP=$(ip addr show "$interface" | awk '/inet / {print $2}' | cut -d/ -f1)
     sudo kubeadm init --apiserver-advertise-address="$MASTER_PRIVATE_IP" --apiserver-cert-extra-sans="$MASTER_PRIVATE_IP" --pod-network-cidr="$POD_CIDR" --node-name "$NODENAME" --ignore-preflight-errors Swap
 
 elif [[ "$PUBLIC_IP_ACCESS" == "true" ]]; then


### PR DESCRIPTION
Hey, 
I was deploying and some ot the nodes didn't share the network  interface eth0, so to avoid that problem, interface is a variable that automatically is get by the script in case network interface is ens192 or ens160 and not directory eth0