### PR TITLE
Update metrics-server.yaml

### DIFF
--- a/manifests/metrics-server.yaml
+++ b/manifests/metrics-server.yaml
@@ -130,11 +130,12 @@ spec:
       labels:
         k8s-app: metrics-server
     spec:
+      hostNetwork: true
       containers:
       - command: 
         - /metrics-server
         - --cert-dir=/tmp
-        - --secure-port=10250
+        - --secure-port=4443
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
@@ -150,7 +151,7 @@ spec:
           periodSeconds: 10
         name: metrics-server
         ports:
-        - containerPort: 10250
+        - containerPort: 4443
           name: https
           protocol: TCP
         readinessProbe:


### PR DESCRIPTION
title: Fix metrics-server configuration for reliable Kubelet communication

## Description
This PR updates the metrics-server configuration to ensure reliable communication with Kubelet components across the cluster.

## Changes Made
- Added `hostNetwork: true` to allow direct host network access
- Changed container port from 10250 to 4443 to avoid conflicts
- Updated metrics-server arguments for secure Kubelet communication

## Related Issues
- Fixes "Metrics API not available" errors
